### PR TITLE
Flexible selector

### DIFF
--- a/cyrlatconverter-v0.5.4.js
+++ b/cyrlatconverter-v0.5.4.js
@@ -102,7 +102,7 @@
 		button_cyr : '',
 		button_lat : '',
 		button_default : '',
-		elements : ''
+		elements : '.CyrLatConvert'
 	};
 	
 	var Lat2Cyr = {
@@ -646,7 +646,7 @@
 			if(config.benchmark.toString().toLowerCase() == 'on' && !init_benchmark_active)
 				var start = new Date().getTime();
 			
-			$(elements).each(function() {			
+			$(config.elements).each(function() {			
 				convert_L2C(this);
 			});
 			setCookie('L2C');
@@ -666,7 +666,7 @@
 			if(config.benchmark.toString().toLowerCase() == 'on' && !init_benchmark_active)
 				var start = new Date().getTime();
 			
-			$(elements).each(function() {			
+			$(config.elements).each(function() {			
 				convert_C2L(this);
 			});
 			setCookie('C2L');
@@ -713,4 +713,3 @@
 	};
 
 })(jQuery); 
-#lat


### PR DESCRIPTION
With this change any element can be transliterated, no need to change html and add CyrLatConvert class. When calling the function, elements to which transliteration applies should be passed. To get old behaviour, we would call function like

```
$.CyrLatConverter({
         button_cyr : "cyr_id",
         button_lat : "lat_id",
         elements : ".CyrLatConvert"
      });
```

Or we can pass different elements

``````
$.CyrLatConverter({
         button_cyr : "cyr_id",
         button_lat : "lat_id",
         elements : "#id, .class, ul"
      });```
``````
